### PR TITLE
Add SSL/TLS support. Ref #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,19 @@ c2.close();
 System.out.println("num active "+connectionPool.getNumActive());
 System.out.println("num idle "+connectionPool.getNumIdle());
 ```
+
+## SSL/TLS connections
+
+Connections can be encrypted via SSL/TLS by setting the connection property `ssl` to the string value `true`.
+For example:
+
+```java
+Properties props = new Properties();
+props.setProperty("user", "my_user");
+props.setProperty("password", "my_password");
+props.setProperty("ssl", "true");
+h = DriverManager.getConnection("jdbc:q:localhost:5001",props);
+```
+
+The connection may require certificates/keys to registered via JSSE (as referenced [here](https://github.com/KxSystems/javakdb/tree/master/docs#ssltls))
+and the kdb+ server to be configured to accept SSL/TLS connections.

--- a/jdbc-example/pom.xml
+++ b/jdbc-example/pom.xml
@@ -6,13 +6,13 @@
 
   <groupId>com.kx</groupId>
   <artifactId>jdbc-example</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>com.kx</groupId>
     <artifactId>JdbcModules</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
   </parent>
 
   <name>JDBC_KDB_EXAMPLE</name>
@@ -46,7 +46,7 @@
    <dependency>
       <groupId>com.kx</groupId>
       <artifactId>jdbc</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <version>1.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -6,13 +6,13 @@
 
   <groupId>com.kx</groupId>
   <artifactId>jdbc</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>com.kx</groupId>
     <artifactId>JdbcModules</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
   </parent>
 
   <name>JDBC_KDB</name>

--- a/jdbc/src/main/java/com/kx/jdbc.java
+++ b/jdbc/src/main/java/com/kx/jdbc.java
@@ -38,7 +38,12 @@ public int getMajorVersion(){return MAJOR_VERSION;}
 public int getMinorVersion(){return MINOR_VERSION;}
 public boolean jdbcCompliant(){return false;}
 public boolean acceptsURL(String s){return s.startsWith("jdbc:q:");}
-public Connection connect(String s,Properties p)throws SQLException{return!acceptsURL(s)?null:new co(s.substring(7),p!=null?p.get("user"):p,p!=null?p.get("password"):p);}
+public Connection connect(String s,Properties p)throws SQLException{
+  if(!acceptsURL(s))
+    return null;
+  return new co(s.substring(7),p.get("user"),p.get("password"),p.get("ssl"));
+}
+
 public DriverPropertyInfo[]getPropertyInfo(String s,Properties p)throws SQLException{return new DriverPropertyInfo[0];}
 static{try{DriverManager.registerDriver(new jdbc());}catch(Exception e){O(e.getMessage());}}
 static final int[]SQLTYPE={0,16,0,0,-2,5,4,-5,7,8,0,12,0,0,91,93,0,0,0,92};
@@ -78,10 +83,10 @@ public class co implements Connection{
   * @param p password
   * @throws SQLException issue connecting to kdb+
   */
- public co(String s,Object u,Object p)throws SQLException{
+ public co(String s,Object u,Object p,Object ssl)throws SQLException{
    int idx=s.indexOf(":");
    try{
-    c=new c(s.substring(0,idx),Integer.parseInt(s.substring(idx+1)),u==null?"":(String)u+":"+(String)p);
+    c=new c(s.substring(0,idx),Integer.parseInt(s.substring(idx+1)),u==null?"":(String)u+":"+(String)p,ssl!=null&&"true".equals(ssl));
     c.setCollectResponseAsync(true);
    }catch(Exception e){
     q(e);

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>com.kx</groupId>
   <artifactId>JdbcModules</artifactId>
   <packaging>pom</packaging>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1-SNAPSHOT</version>
 
   <name>JDBC_KDB_MULTI</name>
   <description>JDBC client for kdb+</description>


### PR DESCRIPTION
Example:
running kdb+ server as 
```bash
export SSL_CERT_FILE=/Development/certs/server-cert.pem
export SSL_KEY_FILE=/Development/certs/server-private-key.pem
export SSL_CA_CERT_FILE=/Development/certs/ca-cert.pem 
q ps.k -E 2 -p 5001
```
and Example1 changed to created a connection via 
```java
      Properties props = new Properties(); 
      props.setProperty("user", "property_testuser");
      props.setProperty("password", "properttestpassword");
      props.setProperty("ssl", "true");
      h = DriverManager.getConnection(url,props);
```
running the example show it connecting via SSL/TLS.
```bash
mvn exec:java -pl jdbc-example -Dexec.mainClass="com.kx.jdbcexamples.Example1" -Djavax.net.ssl.keyStore=/Development/keystore.p12 -Djavax.net.ssl.keyStorePassword=testtest -D=javax.net.ssl.trustStore=/Development/truststore.jks -D=javax.net.ssl.trustStorePassword=changeit 
```

Reference https://github.com/KxSystems/javakdb/pull/90/files for ssl/tls setup